### PR TITLE
Fix invalid move bug

### DIFF
--- a/src/main/java/quentin/ConsoleQuentin.java
+++ b/src/main/java/quentin/ConsoleQuentin.java
@@ -80,8 +80,6 @@ public class ConsoleQuentin extends Quentin<ConsoleInputHandler, ConsoleOutputHa
             if (askForPieRule(currentPlayer)) { continue; }
             getPositionAndMakeMove(currentPlayer);
             if (checkForWinner()) { break; }
-//            fillTerritories();
-            if (checkForWinner()) { break; }
         }
     }
 

--- a/src/main/java/quentin/ConsoleQuentin.java
+++ b/src/main/java/quentin/ConsoleQuentin.java
@@ -80,7 +80,7 @@ public class ConsoleQuentin extends Quentin<ConsoleInputHandler, ConsoleOutputHa
             if (askForPieRule(currentPlayer)) { continue; }
             getPositionAndMakeMove(currentPlayer);
             if (checkForWinner()) { break; }
-            fillTerritories();
+//            fillTerritories();
             if (checkForWinner()) { break; }
         }
     }

--- a/src/main/java/quentin/UI/GUI/GUI.java
+++ b/src/main/java/quentin/UI/GUI/GUI.java
@@ -25,9 +25,10 @@ import quentin.UI.GUI.Handlers.GuiPassHandler;
 import quentin.UI.GUI.Handlers.GuiPieHandler;
 import quentin.GUIQuentin;
 import quentin.core.Intersection;
-import quentin.core.Player;
 
 import java.util.stream.Stream;
+
+import static java.util.function.Predicate.not;
 
 public class GUI extends Application {
 
@@ -167,23 +168,19 @@ public class GUI extends Application {
         structureUI(replayButtons(), "Do you wanna play again?", 20, 100);
     }
 
-    public void fillGridBoardWithTerritories() {
-        guiQuentin.getTerritoriesAndStones(guiQuentin.getLastPlay()).forEach((territory, stone) ->
-                territory.stream().map(Intersection::getPosition).
-                        forEach(position -> boardFiller.
-                                addPiece(this.getGridBoard(),
-                                        position.getColumn() - 1, // to be consistent with the board gui representation
-                                        position.getRow() - 1, // to be consistent with the board gui representation
-                                        stone)));
-    }
-
     @Override
     public void stop() { Platform.exit(); }
 
-    public void updateGUI(int columnIndex, int rowIndex, Player currentPlayer) {
-        boardFiller.addPiece(getGridBoard(), columnIndex, rowIndex, currentPlayer.getColor());
-        fillGridBoardWithTerritories();
-//        getGame().fillTerritories();
+    public void updateGUI() {
+        guiQuentin.getBoard().getIntersections().stream()
+                .filter(not(Intersection::isEmpty))
+                .forEach(nonEmptyIntersection ->
+                        boardFiller.addPiece(getGridBoard(),
+                                nonEmptyIntersection.getPosition().getColumn() - 1,
+                                nonEmptyIntersection.getPosition().getRow() - 1,
+                                nonEmptyIntersection.getStone()
+                        )
+                );
         boardFiller.switchLabelsCurrentPlayer(getLabelBoard());
     }
 

--- a/src/main/java/quentin/UI/GUI/GUI.java
+++ b/src/main/java/quentin/UI/GUI/GUI.java
@@ -183,7 +183,7 @@ public class GUI extends Application {
     public void updateGUI(int columnIndex, int rowIndex, Player currentPlayer) {
         boardFiller.addPiece(getGridBoard(), columnIndex, rowIndex, currentPlayer.getColor());
         fillGridBoardWithTerritories();
-        getGame().fillTerritories();
+//        getGame().fillTerritories();
         boardFiller.switchLabelsCurrentPlayer(getLabelBoard());
     }
 

--- a/src/main/java/quentin/UI/GUI/GUIBoardDisplayer.java
+++ b/src/main/java/quentin/UI/GUI/GUIBoardDisplayer.java
@@ -21,7 +21,7 @@ public class GUIBoardDisplayer {
     private final int tileSize;
     private static final EnumMap<Stone, Paint> colorPaintMap = new EnumMap<> (Stone.class);
 
-    GUIBoardDisplayer(int boardSize, int tileSize) {
+    protected GUIBoardDisplayer(int boardSize, int tileSize) {
         this.boardSize = boardSize;
         this.tileSize = tileSize;
 
@@ -29,7 +29,7 @@ public class GUIBoardDisplayer {
         colorPaintMap.put(Stone.WHITE, Color.WHITE);
     }
 
-    GridPane createEmptyBoard() {
+    protected GridPane createEmptyBoard() {
 
         GridPane gridPane = new GridPane();
         gridPane.setStyle("-fx-background-color: #3CB371");
@@ -88,7 +88,7 @@ public class GUIBoardDisplayer {
         return generatedLine;
     }
 
-    void addPiece(GridPane gridPane, int coordinateX, int coordinateY, Stone stone) {
+    protected void addPiece(GridPane gridPane, int coordinateX, int coordinateY, Stone stone) {
         Circle piece = new Circle(coordinateX * tileSize, coordinateY * tileSize, tileSize * 0.4);
         piece.setFill(colorPaintMap.get(stone));
         GridPane.setHalignment(piece, HPos.CENTER);
@@ -96,7 +96,7 @@ public class GUIBoardDisplayer {
         gridPane.add(piece, coordinateX, coordinateY);
     }
 
-    GridPane createLabelPane(String namePLayerOne, String namePlayerTwo) {
+    protected GridPane createLabelPane(String namePLayerOne, String namePlayerTwo) {
         GridPane gridLabels = new GridPane();
         gridLabels.setVgap(10);
 
@@ -115,7 +115,7 @@ public class GUIBoardDisplayer {
         return gridLabels;
     }
 
-    void switchColorPlayerLabel(GridPane labelBoard){
+    protected void switchColorPlayerLabel(GridPane labelBoard){
         switchColorLabel(labelBoard, 3, Color.BLACK);
         switchColorLabel(labelBoard, 4, Color.WHITE);
     }
@@ -125,7 +125,7 @@ public class GUIBoardDisplayer {
         currentPlayerLabel.setFill(color);
     }
 
-    void switchLabelsCurrentPlayer(GridPane labelBoard){
+    protected void switchLabelsCurrentPlayer(GridPane labelBoard){
         Circle currentPlayerLabel = (Circle) labelBoard.getChildren().get(5);
         currentPlayerLabel.setFill(currentPlayerLabel.getFill() == Color.BLACK ? Color.WHITE : Color.BLACK);
     }

--- a/src/main/java/quentin/UI/GUI/GUIInputHandler.java
+++ b/src/main/java/quentin/UI/GUI/GUIInputHandler.java
@@ -22,7 +22,7 @@ public class GUIInputHandler implements InputHandler {
         return result.filter(buttonType -> buttonType == ButtonType.OK).isPresent();
     }
 
-    int askSize() {
+    protected int askSize() {
         List<Integer> sizes = List.of(4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
         ChoiceDialog<Integer> dialog = new ChoiceDialog<>(13, sizes);
 
@@ -34,7 +34,7 @@ public class GUIInputHandler implements InputHandler {
         return dialog.showAndWait().orElse(dialog.getDefaultChoice());
     }
 
-    String askPlayerName(String playerNumber) {
+    protected String askPlayerName(String playerNumber) {
 
         TextInputDialog dialog = new TextInputDialog("Player ".concat(playerNumber));
         dialog.setTitle("Enter name player " + playerNumber);

--- a/src/main/java/quentin/UI/GUI/Handlers/GuiMouseHandler.java
+++ b/src/main/java/quentin/UI/GUI/Handlers/GuiMouseHandler.java
@@ -4,7 +4,6 @@ import javafx.event.EventHandler;
 import javafx.scene.input.MouseEvent;
 import quentin.GUIQuentin;
 import quentin.UI.GUI.GUI;
-import quentin.core.Player;
 import quentin.core.Position;
 import quentin.exceptions.QuentinException;
 
@@ -26,7 +25,6 @@ public class GuiMouseHandler implements EventHandler<MouseEvent> {
 
         game.setNewPosition(Position.in(rowIndex + 1, columnIndex + 1));
 
-        Player currentPlayer = game.getCurrentPlayer();
         if (game.isCurrentPlayerNotAbleToMakeAMove()) {
             game.passTurn();
             return;
@@ -39,7 +37,7 @@ public class GuiMouseHandler implements EventHandler<MouseEvent> {
             return;
         }
 
-        gui.updateGUI(columnIndex, rowIndex, currentPlayer);
+        gui.updateGUI();
         gui.fireEvents();
         event.consume();
     }

--- a/src/main/java/quentin/UI/console/ConsoleOutputHandler.java
+++ b/src/main/java/quentin/UI/console/ConsoleOutputHandler.java
@@ -63,7 +63,7 @@ public class ConsoleOutputHandler implements quentin.UI.OutputHandler {
     }
 
     private void displayRow(Board board, int rowIndex) {
-        System.out.print(rowIndex + "   ");
+        System.out.print(rowIndex >= 10 ? rowIndex + "  " : rowIndex + "   ");
         System.out.print("W");
         IntStream.rangeClosed(1, board.getBoardSize())
                 .forEach(columnIndex ->
@@ -77,7 +77,7 @@ public class ConsoleOutputHandler implements quentin.UI.OutputHandler {
         IntStream.rangeClosed(1, board.getBoardSize()).forEach(rowIndex -> displayRow(board, rowIndex));
         System.out.print("    " + "  B".repeat(board.getBoardSize()) + System.lineSeparator() + "    ");
         IntStream.rangeClosed(1, board.getBoardSize())
-                .forEachOrdered(columnIndex -> System.out.print("  " + columnIndex));
+                .forEachOrdered(columnIndex -> System.out.print(columnIndex < 10 ? "  " + columnIndex : " " + columnIndex));
         System.out.println();
     }
 }

--- a/src/main/java/quentin/UI/console/ConsoleOutputHandler.java
+++ b/src/main/java/quentin/UI/console/ConsoleOutputHandler.java
@@ -63,7 +63,7 @@ public class ConsoleOutputHandler implements quentin.UI.OutputHandler {
     }
 
     private void displayRow(Board board, int rowIndex) {
-        System.out.print(rowIndex >= 10 ? rowIndex + "  " : rowIndex + "   ");
+        System.out.print(rowIndex < 10 ? rowIndex + "   " : rowIndex + "  ");
         System.out.print("W");
         IntStream.rangeClosed(1, board.getBoardSize())
                 .forEach(columnIndex ->

--- a/src/main/java/quentin/core/Board.java
+++ b/src/main/java/quentin/core/Board.java
@@ -42,10 +42,6 @@ public class Board {
         chainContainer.updateChain(intersection);
     }
 
-    void updateChains(Position intersectionPosition) {
-        chainContainer.updateChain(intersectionAt(intersectionPosition));
-    }
-
     protected boolean isOccupied(Position position) throws OutsideOfBoardException {
         return intersectionAt(position).isOccupied();
     }
@@ -95,11 +91,10 @@ public class Board {
         return BOARD_SIZE;
     }
 
-    protected void updateRegions(Intersection intersection) {
-        regionsContainer.addIntersection(intersection);
-    }
-
-    protected void removeFromChain(Intersection intersection) {
+    public void revertForIntersectionIn(Position position) {
+        Intersection intersection = intersectionAt(position);
         chainContainer.removeIntersection(intersection);
+        intersection.setStone(Stone.NONE);
+        regionsContainer.addIntersection(intersection);
     }
 }

--- a/src/main/java/quentin/core/Board.java
+++ b/src/main/java/quentin/core/Board.java
@@ -56,7 +56,7 @@ public class Board {
     protected Set<Intersection> getOrthogonallyAdjacentIntersectionsOfColour(Intersection intersection, Stone color) {
         return intersections.stream()
                 .filter(intersection::isOrthogonalTo)
-                .filter(diagonalIntersection -> diagonalIntersection.hasStone(color))
+                .filter(orthogonalIntersection -> orthogonalIntersection.hasStone(color))
                 .collect(Collectors.toUnmodifiableSet());
     }
 

--- a/src/main/java/quentin/core/Board.java
+++ b/src/main/java/quentin/core/Board.java
@@ -3,6 +3,7 @@ package quentin.core;
 import quentin.exceptions.OutsideOfBoardException;
 
 import java.util.*;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static quentin.core.Position.in;
@@ -59,16 +60,18 @@ public class Board {
                 );
     }
 
-    protected Stream<Intersection> getColourAlikeDiagonallyAdjacentIntersections(Intersection intersection) {
+    protected Set<Intersection> getColourAlikeDiagonallyAdjacentIntersections(Intersection intersection) {
         return intersections.stream()
-                .filter(intersection::isOrthogonalTo)
-                .filter(diagonalIntersection -> intersection.hasStone(diagonalIntersection.getStone()));
+                .filter(intersection::isDiagonalTo)
+                .filter(diagonalIntersection -> intersection.hasStone(diagonalIntersection.getStone()))
+                .collect(Collectors.toUnmodifiableSet());
     }
 
-    protected Stream<Intersection> getOrthogonallyAdjacentIntersections(Intersection intersection) {
+    protected Set<Intersection> getOrthogonallyAdjacentIntersections(Intersection intersection) {
         return intersections.stream()
                 .filter(intersection::isOrthogonalTo)
-                .filter(diagonalIntersection -> intersection.hasStone(diagonalIntersection.getStone()));
+                .filter(diagonalIntersection -> intersection.hasStone(diagonalIntersection.getStone()))
+                .collect(Collectors.toUnmodifiableSet());
     }
 
     protected Stone colorWithCompleteChain() {

--- a/src/main/java/quentin/core/Board.java
+++ b/src/main/java/quentin/core/Board.java
@@ -37,8 +37,8 @@ public class Board {
 
     protected void addStoneAt(Stone stone, Position position) throws OutsideOfBoardException {
         Intersection intersection = intersectionAt(position);
+        regionsContainer.removeIntersection(intersection);
         intersection.setStone(stone);
-        regionsContainer.updateRegionContainer(intersection);
         chainContainer.updateChain(intersection);
     }
 
@@ -93,5 +93,13 @@ public class Board {
 
     public int getBoardSize() {
         return BOARD_SIZE;
+    }
+
+    protected void updateRegions(Intersection intersection) {
+        regionsContainer.addIntersection(intersection);
+    }
+
+    protected void removeFromChain(Intersection intersection) {
+        chainContainer.removeIntersection(intersection);
     }
 }

--- a/src/main/java/quentin/core/Board.java
+++ b/src/main/java/quentin/core/Board.java
@@ -70,7 +70,6 @@ public class Board {
 
     protected Set<Position> fillTerritories(Stone lastPlay) {
         Map<Set<Intersection>, Stone> territoriesToFill = getTerritoriesAndStones(lastPlay);
-
         territoriesToFill
                 .forEach((territory, stone) ->
                                 territory.stream()

--- a/src/main/java/quentin/core/Board.java
+++ b/src/main/java/quentin/core/Board.java
@@ -67,7 +67,7 @@ public class Board {
                 .collect(Collectors.toUnmodifiableSet());
     }
 
-    protected Set<Intersection> getOrthogonallyAdjacentIntersections(Intersection intersection) {
+    protected Set<Intersection> getColourAlikeOrthogonallyAdjacentIntersections(Intersection intersection) {
         return intersections.stream()
                 .filter(intersection::isOrthogonalTo)
                 .filter(diagonalIntersection -> intersection.hasStone(diagonalIntersection.getStone()))

--- a/src/main/java/quentin/core/Board.java
+++ b/src/main/java/quentin/core/Board.java
@@ -60,17 +60,17 @@ public class Board {
                 );
     }
 
-    protected Set<Intersection> getColourAlikeDiagonallyAdjacentIntersections(Intersection intersection) {
+    protected Set<Intersection> getDiagonallyAdjacentIntersectionsOfColour(Intersection intersection, Stone color) {
         return intersections.stream()
                 .filter(intersection::isDiagonalTo)
-                .filter(diagonalIntersection -> intersection.hasStone(diagonalIntersection.getStone()))
+                .filter(diagonalIntersection -> diagonalIntersection.hasStone(color))
                 .collect(Collectors.toUnmodifiableSet());
     }
 
-    protected Set<Intersection> getColourAlikeOrthogonallyAdjacentIntersections(Intersection intersection) {
+    protected Set<Intersection> getOrthogonallyAdjacentIntersectionsOfColour(Intersection intersection, Stone color) {
         return intersections.stream()
                 .filter(intersection::isOrthogonalTo)
-                .filter(diagonalIntersection -> intersection.hasStone(diagonalIntersection.getStone()))
+                .filter(diagonalIntersection -> diagonalIntersection.hasStone(color))
                 .collect(Collectors.toUnmodifiableSet());
     }
 

--- a/src/main/java/quentin/core/Board.java
+++ b/src/main/java/quentin/core/Board.java
@@ -84,7 +84,7 @@ public class Board {
         return territoriesToFill.entrySet().stream()
                 .flatMap(entry -> entry.getKey().stream())
                 .map(Intersection::getPosition)
-                .collect(Collectors.toUnmodifiableSet());
+                .collect(Collectors.toSet());
     }
 
     protected Map<Set<Intersection>, Stone> getTerritoriesAndStones(Stone lastPlay){

--- a/src/main/java/quentin/core/Board.java
+++ b/src/main/java/quentin/core/Board.java
@@ -37,9 +37,13 @@ public class Board {
 
     protected void addStoneAt(Stone stone, Position position) throws OutsideOfBoardException {
         Intersection intersection = intersectionAt(position);
-        regionsContainer.removeNonEmptyIntersection(intersection);
         intersection.setStone(stone);
+        regionsContainer.updateRegionContainer(intersection);
         chainContainer.updateChain(intersection);
+    }
+
+    void updateChains(Position intersectionPosition) {
+        chainContainer.updateChain(intersectionAt(intersectionPosition));
     }
 
     protected boolean isOccupied(Position position) throws OutsideOfBoardException {
@@ -68,13 +72,19 @@ public class Board {
         return intersections.stream().filter(intersection -> !intersection.isOccupied());
     }
 
-    protected void fillTerritories(Stone lastPlay) {
-        getTerritoriesAndStones(lastPlay)
-                        .forEach((territory, stone) ->
+    protected Set<Position> fillTerritories(Stone lastPlay) {
+        Map<Set<Intersection>, Stone> territoriesToFill = getTerritoriesAndStones(lastPlay);
+
+        territoriesToFill
+                .forEach((territory, stone) ->
                                 territory.stream()
                                         .map(Intersection::getPosition)
                                         .forEach(emptyIntersectionPosition -> addStoneAt(stone, emptyIntersectionPosition))
-                        );
+                );
+        return territoriesToFill.entrySet().stream()
+                .flatMap(entry -> entry.getKey().stream())
+                .map(Intersection::getPosition)
+                .collect(Collectors.toUnmodifiableSet());
     }
 
     protected Map<Set<Intersection>, Stone> getTerritoriesAndStones(Stone lastPlay){

--- a/src/main/java/quentin/core/Board.java
+++ b/src/main/java/quentin/core/Board.java
@@ -96,4 +96,8 @@ public class Board {
         intersection.setStone(Stone.NONE);
         regionsContainer.addIntersection(intersection);
     }
+
+    public List<Intersection> getIntersections() {
+        return this.intersections;
+    }
 }

--- a/src/main/java/quentin/core/Board.java
+++ b/src/main/java/quentin/core/Board.java
@@ -46,20 +46,6 @@ public class Board {
         return intersectionAt(position).isOccupied();
     }
 
-    protected boolean existsOrthogonallyAdjacentWithStone(Intersection intersection, Stone stone) {
-        return intersections.stream()
-                .anyMatch(otherIntersection ->
-                        otherIntersection.isOrthogonalTo(intersection) && otherIntersection.hasStone(stone)
-                );
-    }
-
-    protected boolean existsDiagonallyAdjacentWithStone(Intersection intersection, Stone stone) {
-        return intersections.stream()
-                .anyMatch(otherIntersection ->
-                        otherIntersection.isDiagonalTo(intersection) && otherIntersection.hasStone(stone)
-                );
-    }
-
     protected Set<Intersection> getDiagonallyAdjacentIntersectionsOfColour(Intersection intersection, Stone color) {
         return intersections.stream()
                 .filter(intersection::isDiagonalTo)

--- a/src/main/java/quentin/core/Board.java
+++ b/src/main/java/quentin/core/Board.java
@@ -90,7 +90,7 @@ public class Board {
         return BOARD_SIZE;
     }
 
-    public void revertForIntersectionIn(Position position) {
+    public void revertForIntersectionAt(Position position) {
         Intersection intersection = intersectionAt(position);
         chainContainer.removeIntersection(intersection);
         intersection.setStone(Stone.NONE);

--- a/src/main/java/quentin/core/Board.java
+++ b/src/main/java/quentin/core/Board.java
@@ -90,14 +90,14 @@ public class Board {
         return BOARD_SIZE;
     }
 
-    public void revertForIntersectionAt(Position position) {
+    protected void revertForIntersectionAt(Position position) {
         Intersection intersection = intersectionAt(position);
         chainContainer.removeIntersection(intersection);
         intersection.setStone(Stone.NONE);
         regionsContainer.addIntersection(intersection);
     }
 
-    public List<Intersection> getIntersections() {
+    public final List<Intersection> getIntersections() {
         return this.intersections;
     }
 }

--- a/src/main/java/quentin/core/Board.java
+++ b/src/main/java/quentin/core/Board.java
@@ -59,6 +59,18 @@ public class Board {
                 );
     }
 
+    protected Stream<Intersection> getColourAlikeDiagonallyAdjacentIntersections(Intersection intersection) {
+        return intersections.stream()
+                .filter(intersection::isOrthogonalTo)
+                .filter(diagonalIntersection -> intersection.hasStone(diagonalIntersection.getStone()));
+    }
+
+    protected Stream<Intersection> getOrthogonallyAdjacentIntersections(Intersection intersection) {
+        return intersections.stream()
+                .filter(intersection::isOrthogonalTo)
+                .filter(diagonalIntersection -> intersection.hasStone(diagonalIntersection.getStone()));
+    }
+
     protected Stone colorWithCompleteChain() {
         return chainContainer.getColorWithCompleteChain();
     }

--- a/src/main/java/quentin/core/BoardSide.java
+++ b/src/main/java/quentin/core/BoardSide.java
@@ -54,9 +54,9 @@ public enum BoardSide {
         this.color = color;
     }
 
-    public abstract void initialiseSide();
+    protected abstract void initialiseSide();
 
-    public abstract boolean isAdjacentTo(Position position);
+    protected abstract boolean isAdjacentTo(Position position);
 
     protected int getSideIndex() {
         return this.sideIndex;

--- a/src/main/java/quentin/core/ChainContainer.java
+++ b/src/main/java/quentin/core/ChainContainer.java
@@ -13,7 +13,6 @@ public class ChainContainer {
     private final Set<BoardSide> sides = EnumSet.allOf(BoardSide.class);
 
     ChainContainer(int boardSize) {
-
         chains.put(Stone.BLACK, new SimpleGraph<>(DefaultEdge.class));
         chains.put(Stone.WHITE, new SimpleGraph<>(DefaultEdge.class));
 
@@ -23,11 +22,11 @@ public class ChainContainer {
 
     protected void updateChain(Intersection newIntersection) {
         Optional<Graph<Intersection, DefaultEdge>> chainsOfColor = Optional.ofNullable(chains.get(newIntersection.getStone()));
-        chainsOfColor.ifPresent(chains -> {
-            chains.addVertex(newIntersection);
-            chains.vertexSet().stream()
+        chainsOfColor.ifPresent(chainsOfSingleColor -> {
+            chainsOfSingleColor.addVertex(newIntersection);
+            chainsOfSingleColor.vertexSet().stream()
                     .filter(newIntersection::isOrthogonalTo)
-                    .forEach(orthogonalIntersection -> chains.addEdge(orthogonalIntersection, newIntersection));
+                    .forEach(orthogonalIntersection -> chainsOfSingleColor.addEdge(orthogonalIntersection, newIntersection));
         });
     }
 

--- a/src/main/java/quentin/core/ChainContainer.java
+++ b/src/main/java/quentin/core/ChainContainer.java
@@ -23,16 +23,20 @@ public class ChainContainer {
 
     protected void updateChain(Intersection newIntersection) {
         Optional<Graph<Intersection, DefaultEdge>> chainsOfColor = Optional.ofNullable(chains.get(newIntersection.getStone()));
-        chainsOfColor.ifPresentOrElse(chains -> {
+        chainsOfColor.ifPresent(chains -> {
             chains.addVertex(newIntersection);
             chains.vertexSet().stream()
                     .filter(newIntersection::isOrthogonalTo)
                     .forEach(orthogonalIntersection -> chains.addEdge(orthogonalIntersection, newIntersection));
-        }, () -> chains.forEach((key, value) -> value.removeVertex(newIntersection)));
+        });//, () -> chains.forEach((key, value) -> value.removeVertex(newIntersection)));
 //        chainsOfColor.addVertex(newIntersection);
 //        chainsOfColor.vertexSet().stream()
 //                .filter(newIntersection::isOrthogonalTo)
 //                .forEach(orthogonalIntersection -> chainsOfColor.addEdge(orthogonalIntersection, newIntersection));
+    }
+
+    protected void removeIntersection(Intersection intersection) {
+        chains.get(intersection.getStone()).removeVertex(intersection);
     }
 
     private boolean hasACompleteChain(Map.Entry<Stone, Graph<Intersection, DefaultEdge>> chainsOfAGivenColor) {

--- a/src/main/java/quentin/core/ChainContainer.java
+++ b/src/main/java/quentin/core/ChainContainer.java
@@ -28,11 +28,7 @@ public class ChainContainer {
             chains.vertexSet().stream()
                     .filter(newIntersection::isOrthogonalTo)
                     .forEach(orthogonalIntersection -> chains.addEdge(orthogonalIntersection, newIntersection));
-        });//, () -> chains.forEach((key, value) -> value.removeVertex(newIntersection)));
-//        chainsOfColor.addVertex(newIntersection);
-//        chainsOfColor.vertexSet().stream()
-//                .filter(newIntersection::isOrthogonalTo)
-//                .forEach(orthogonalIntersection -> chainsOfColor.addEdge(orthogonalIntersection, newIntersection));
+        });
     }
 
     protected void removeIntersection(Intersection intersection) {

--- a/src/main/java/quentin/core/ChainContainer.java
+++ b/src/main/java/quentin/core/ChainContainer.java
@@ -22,11 +22,17 @@ public class ChainContainer {
     }
 
     protected void updateChain(Intersection newIntersection) {
-        Graph<Intersection, DefaultEdge> chainsOfColor = chains.get(newIntersection.getStone());
-        chainsOfColor.addVertex(newIntersection);
-        chainsOfColor.vertexSet().stream()
-                .filter(newIntersection::isOrthogonalTo)
-                .forEach(orthogonalIntersection -> chainsOfColor.addEdge(orthogonalIntersection, newIntersection));
+        Optional<Graph<Intersection, DefaultEdge>> chainsOfColor = Optional.ofNullable(chains.get(newIntersection.getStone()));
+        chainsOfColor.ifPresentOrElse(chains -> {
+            chains.addVertex(newIntersection);
+            chains.vertexSet().stream()
+                    .filter(newIntersection::isOrthogonalTo)
+                    .forEach(orthogonalIntersection -> chains.addEdge(orthogonalIntersection, newIntersection));
+        }, () -> chains.forEach((key, value) -> value.removeVertex(newIntersection)));
+//        chainsOfColor.addVertex(newIntersection);
+//        chainsOfColor.vertexSet().stream()
+//                .filter(newIntersection::isOrthogonalTo)
+//                .forEach(orthogonalIntersection -> chainsOfColor.addEdge(orthogonalIntersection, newIntersection));
     }
 
     private boolean hasACompleteChain(Map.Entry<Stone, Graph<Intersection, DefaultEdge>> chainsOfAGivenColor) {

--- a/src/main/java/quentin/core/ChainContainer.java
+++ b/src/main/java/quentin/core/ChainContainer.java
@@ -55,7 +55,7 @@ public class ChainContainer {
         return sides.stream().filter(side -> side.hasColor(color)).collect(Collectors.toList());
     }
 
-    public Stone getColorWithCompleteChain() {
+    protected Stone getColorWithCompleteChain() {
         return chains.entrySet().stream()
                 .filter(this::hasACompleteChain)
                 .map(Map.Entry::getKey)

--- a/src/main/java/quentin/core/Intersection.java
+++ b/src/main/java/quentin/core/Intersection.java
@@ -45,7 +45,7 @@ public class Intersection {
     }
 
     protected boolean isOccupied() {
-        return !hasStone(Stone.NONE);
+        return !this.isEmpty();
     }
 
     protected boolean isOrthogonalTo(Intersection otherIntersection) {
@@ -56,9 +56,11 @@ public class Intersection {
         return position.isDiagonalTo(otherIntersection.getPosition());
     }
 
-    protected boolean hasStone(Stone stone) {
+    public boolean hasStone(Stone stone) {
         return this.stone == stone;
     }
+
+    public boolean isEmpty() { return hasStone(Stone.NONE); }
 
     @Override
     public String toString() {

--- a/src/main/java/quentin/core/Intersection.java
+++ b/src/main/java/quentin/core/Intersection.java
@@ -6,7 +6,7 @@ public class Intersection {
     private final Position position;
     private Stone stone;
 
-    public Intersection(Position position, Stone stone) {
+    protected Intersection(Position position, Stone stone) {
         this.position = position;
         this.stone = stone;
     }
@@ -28,11 +28,11 @@ public class Intersection {
         return new Intersection(position, Stone.NONE);
     }
 
-    public Position getPosition() {
+    public final Position getPosition() {
         return this.position;
     }
 
-    public Stone getStone() {
+    public final Stone getStone() {
         return this.stone;
     }
 

--- a/src/main/java/quentin/core/Player.java
+++ b/src/main/java/quentin/core/Player.java
@@ -9,15 +9,15 @@ public class Player {
         this.name = name;
     }
 
-    public Stone getColor() {
+    public final Stone getColor() {
         return color;
     }
 
-    public String getName() {
+    public final String getName() {
         return name;
     }
 
-    public void changeSide() {
+    protected void changeSide() {
         color = color.getOppositeColor();
     }
 }

--- a/src/main/java/quentin/core/Position.java
+++ b/src/main/java/quentin/core/Position.java
@@ -5,7 +5,7 @@ import java.util.Objects;
 public class Position {
     private final int row, column;
 
-    public Position(int row, int column) {
+    private Position(int row, int column) {
         this.row = row;
         this.column = column;
     }
@@ -35,42 +35,42 @@ public class Position {
         return this.column;
     }
 
-    boolean isAboveWithRespectTo(Position otherIntersectionPosition) {
+    protected boolean isAboveWithRespectTo(Position otherIntersectionPosition) {
         return otherIntersectionPosition.getRow() == this.row + 1 &&
                 otherIntersectionPosition.getColumn() == this.column;
     }
 
-    boolean isBelowWithRespectTo(Position otherIntersectionPosition) {
+    protected boolean isBelowWithRespectTo(Position otherIntersectionPosition) {
         return otherIntersectionPosition.getRow() == this.row - 1 &&
                 otherIntersectionPosition.getColumn() == this.column;
     }
 
-    boolean isOnTheLeftWithRespectTo(Position otherIntersectionPosition) {
+    protected boolean isOnTheLeftWithRespectTo(Position otherIntersectionPosition) {
         return otherIntersectionPosition.getColumn() == this.column + 1 &&
                 otherIntersectionPosition.getRow() == this.row;
     }
 
-    boolean isOnTheRightWithRespectTo(Position otherIntersectionPosition) {
+    protected boolean isOnTheRightWithRespectTo(Position otherIntersectionPosition) {
         return otherIntersectionPosition.getColumn() == this.column - 1 &&
                 otherIntersectionPosition.getRow() == this.row;
     }
 
-    boolean isDownLeftRespectTo(Position otherIntersectionPosition) {
+    protected boolean isDownLeftRespectTo(Position otherIntersectionPosition) {
         return otherIntersectionPosition.getRow() == this.row - 1 &&
                 otherIntersectionPosition.getColumn() == this.column + 1;
     }
 
-    boolean isUpLeftRespectTo(Position otherIntersectionPosition) {
+    protected boolean isUpLeftRespectTo(Position otherIntersectionPosition) {
         return otherIntersectionPosition.getRow() == this.row + 1 &&
                 otherIntersectionPosition.getColumn() == this.column + 1;
     }
 
-    boolean isDownRightRespectTo(Position otherIntersectionPosition) {
+    protected boolean isDownRightRespectTo(Position otherIntersectionPosition) {
         return otherIntersectionPosition.getRow() == this.row - 1 &&
                 otherIntersectionPosition.getColumn() == this.column - 1;
     }
 
-    boolean isUpRightRespectTo(Position otherIntersectionPosition) {
+    protected boolean isUpRightRespectTo(Position otherIntersectionPosition) {
         return otherIntersectionPosition.getRow() == this.row + 1 &&
                 otherIntersectionPosition.getColumn() == this.column - 1;
     }

--- a/src/main/java/quentin/core/Quentin.java
+++ b/src/main/java/quentin/core/Quentin.java
@@ -41,22 +41,10 @@ public abstract class Quentin<InputHandlerImplementation extends InputHandler, O
 
         if (isIllegalMove(color, position)) {
             territoriesFilled.add(position);
-            revertChanges(territoriesFilled);
+            territoriesFilled.forEach(board::revertForIntersectionIn);
             throw new IllegalMoveException(position);
         }
-//        territoriesFilled.forEach(board::updateChains);
-//        board.updateChains(position);
-//        board.addStoneAt(color, position);
         lastPlay = color;
-    }
-
-    protected void revertChanges(Set<Position> intersectionsToBeReverted) {
-        intersectionsToBeReverted.forEach(position -> {
-            Intersection intersection = board.intersectionAt(position);
-            board.removeFromChain(intersection);
-            intersection.setStone(Stone.NONE);
-            board.updateRegions(intersection);
-        });
     }
 
     private boolean isOccupied(Position position) throws OutsideOfBoardException {
@@ -120,10 +108,6 @@ public abstract class Quentin<InputHandlerImplementation extends InputHandler, O
     public void applyPieRule() {
         Stream.of(playerOne, playerTwo).forEach(Player::changeSide);
     }
-
-//    public void fillTerritories() {
-//        board.fillTerritories(lastPlay);
-//    }
 
     public Map<Set<Intersection>, Stone> getTerritoriesAndStones(Stone stone){
         return board.getTerritoriesAndStones(stone);

--- a/src/main/java/quentin/core/Quentin.java
+++ b/src/main/java/quentin/core/Quentin.java
@@ -8,8 +8,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import static java.util.function.Predicate.not;
-
 public abstract class Quentin<InputHandlerImplementation extends InputHandler, OutputHandlerImplementation extends OutputHandler> {
     private final Board board;
     protected boolean whiteAlreadyPlayed = false;

--- a/src/main/java/quentin/core/Quentin.java
+++ b/src/main/java/quentin/core/Quentin.java
@@ -106,7 +106,7 @@ public abstract class Quentin<InputHandlerImplementation extends InputHandler, O
         return board.colorWithCompleteChain();
     }
 
-    public void applyPieRule() {
+    protected void applyPieRule() {
         Stream.of(playerOne, playerTwo).forEach(Player::changeSide);
     }
 
@@ -118,12 +118,8 @@ public abstract class Quentin<InputHandlerImplementation extends InputHandler, O
         return this.board;
     }
 
-    public Stone getLastPlay() {
-        return this.lastPlay;
-    }
-
     public Player getCurrentPlayer() {
-        return isFirstTurn() ? getPlayerOfColor(Stone.BLACK) : getPlayerOfColor(getLastPlay().getOppositeColor());
+        return isFirstTurn() ? getPlayerOfColor(Stone.BLACK) : getPlayerOfColor(this.lastPlay.getOppositeColor());
     }
 
     public abstract void play() throws QuentinException;

--- a/src/main/java/quentin/core/Quentin.java
+++ b/src/main/java/quentin/core/Quentin.java
@@ -36,11 +36,22 @@ public abstract class Quentin<InputHandlerImplementation extends InputHandler, O
         if (isOccupied(position)) {
             throw new OccupiedPositionException(position);
         }
+        board.addStoneAt(color, position);
+        Set<Position> territoriesFilled = board.fillTerritories(color);
+
         if (isIllegalMove(color, position)) {
+            territoriesFilled.add(position);
+            revertChanges(territoriesFilled);
             throw new IllegalMoveException(position);
         }
-        board.addStoneAt(color, position);
+        territoriesFilled.forEach(board::updateChains);
+        board.updateChains(position);
+//        board.addStoneAt(color, position);
         lastPlay = color;
+    }
+
+    protected void revertChanges(Set<Position> intersectionsToBeReverted) {
+        intersectionsToBeReverted.forEach(position -> board.addStoneAt(Stone.NONE, position));
     }
 
     private boolean isOccupied(Position position) throws OutsideOfBoardException {

--- a/src/main/java/quentin/core/Quentin.java
+++ b/src/main/java/quentin/core/Quentin.java
@@ -6,6 +6,7 @@ import quentin.exceptions.*;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 public abstract class Quentin<InputHandlerImplementation extends InputHandler, OutputHandlerImplementation extends OutputHandler> {
@@ -52,8 +53,15 @@ public abstract class Quentin<InputHandlerImplementation extends InputHandler, O
     }
 
     private boolean isIllegalMove(Stone playerColor, Intersection intersection) {
-        return board.existsDiagonallyAdjacentWithStone(intersection, playerColor) &&
-                !board.existsOrthogonallyAdjacentWithStone(intersection, playerColor);
+        Set<Intersection> colorAlikeOrthogonalIntersections =
+                board.getOrthogonallyAdjacentIntersectionsOfColour(intersection, playerColor);
+        return board.getDiagonallyAdjacentIntersectionsOfColour(intersection, playerColor).stream()
+                .reduce(false,
+                        (partialResult, nextDiagonalIntersection) -> partialResult ||
+                            board.getOrthogonallyAdjacentIntersectionsOfColour(nextDiagonalIntersection, playerColor).stream()
+                                    .allMatch(Predicate.not(colorAlikeOrthogonalIntersections::contains)),
+                        Boolean::logicalOr
+                );
     }
 
     private boolean isARepeatedPlay(Stone playerColor) {

--- a/src/main/java/quentin/core/Quentin.java
+++ b/src/main/java/quentin/core/Quentin.java
@@ -51,7 +51,12 @@ public abstract class Quentin<InputHandlerImplementation extends InputHandler, O
     }
 
     protected void revertChanges(Set<Position> intersectionsToBeReverted) {
-        intersectionsToBeReverted.forEach(position -> board.addStoneAt(Stone.NONE, position));
+        intersectionsToBeReverted.forEach(position -> {
+            Intersection intersection = board.intersectionAt(position);
+            board.removeFromChain(intersection);
+            intersection.setStone(Stone.NONE);
+            board.updateRegions(intersection);
+        });
     }
 
     private boolean isOccupied(Position position) throws OutsideOfBoardException {

--- a/src/main/java/quentin/core/Quentin.java
+++ b/src/main/java/quentin/core/Quentin.java
@@ -110,15 +110,11 @@ public abstract class Quentin<InputHandlerImplementation extends InputHandler, O
         Stream.of(playerOne, playerTwo).forEach(Player::changeSide);
     }
 
-    public Map<Set<Intersection>, Stone> getTerritoriesAndStones(Stone stone){
-        return board.getTerritoriesAndStones(stone);
-    }
-
     protected List<Player> getPlayers() {
         return List.of(playerOne, playerTwo);
     }
 
-    protected Board getBoard() {
+    public Board getBoard() {
         return this.board;
     }
 

--- a/src/main/java/quentin/core/Quentin.java
+++ b/src/main/java/quentin/core/Quentin.java
@@ -36,12 +36,13 @@ public abstract class Quentin<InputHandlerImplementation extends InputHandler, O
         if (isOccupied(position)) {
             throw new OccupiedPositionException(position);
         }
+
         board.addStoneAt(color, position);
         Set<Position> territoriesFilled = board.fillTerritories(color);
 
         if (isIllegalMove(color, position)) {
             territoriesFilled.add(position);
-            territoriesFilled.forEach(board::revertForIntersectionIn);
+            territoriesFilled.forEach(board::revertForIntersectionAt);
             throw new IllegalMoveException(position);
         }
         lastPlay = color;

--- a/src/main/java/quentin/core/Quentin.java
+++ b/src/main/java/quentin/core/Quentin.java
@@ -44,8 +44,8 @@ public abstract class Quentin<InputHandlerImplementation extends InputHandler, O
             revertChanges(territoriesFilled);
             throw new IllegalMoveException(position);
         }
-        territoriesFilled.forEach(board::updateChains);
-        board.updateChains(position);
+//        territoriesFilled.forEach(board::updateChains);
+//        board.updateChains(position);
 //        board.addStoneAt(color, position);
         lastPlay = color;
     }
@@ -116,9 +116,9 @@ public abstract class Quentin<InputHandlerImplementation extends InputHandler, O
         Stream.of(playerOne, playerTwo).forEach(Player::changeSide);
     }
 
-    public void fillTerritories() {
-        board.fillTerritories(lastPlay);
-    }
+//    public void fillTerritories() {
+//        board.fillTerritories(lastPlay);
+//    }
 
     public Map<Set<Intersection>, Stone> getTerritoriesAndStones(Stone stone){
         return board.getTerritoriesAndStones(stone);

--- a/src/main/java/quentin/core/Quentin.java
+++ b/src/main/java/quentin/core/Quentin.java
@@ -6,8 +6,9 @@ import quentin.exceptions.*;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Predicate;
 import java.util.stream.Stream;
+
+import static java.util.function.Predicate.not;
 
 public abstract class Quentin<InputHandlerImplementation extends InputHandler, OutputHandlerImplementation extends OutputHandler> {
     private final Board board;
@@ -56,11 +57,9 @@ public abstract class Quentin<InputHandlerImplementation extends InputHandler, O
         Set<Intersection> colorAlikeOrthogonalIntersections =
                 board.getOrthogonallyAdjacentIntersectionsOfColour(intersection, playerColor);
         return board.getDiagonallyAdjacentIntersectionsOfColour(intersection, playerColor).stream()
-                .reduce(false,
-                        (partialResult, nextDiagonalIntersection) -> partialResult ||
-                            board.getOrthogonallyAdjacentIntersectionsOfColour(nextDiagonalIntersection, playerColor).stream()
-                                    .allMatch(Predicate.not(colorAlikeOrthogonalIntersections::contains)),
-                        Boolean::logicalOr
+                .anyMatch(diagonalIntersection ->
+                        board.getOrthogonallyAdjacentIntersectionsOfColour(diagonalIntersection, playerColor).stream()
+                            .noneMatch(colorAlikeOrthogonalIntersections::contains)
                 );
     }
 

--- a/src/main/java/quentin/core/RegionContainer.java
+++ b/src/main/java/quentin/core/RegionContainer.java
@@ -32,7 +32,7 @@ public class RegionContainer {
         new GridGraphGenerator<Intersection, DefaultEdge>(boardSize, boardSize).generateGraph(graph, null);
     }
 
-    void removeIntersection(Intersection nonEmptyIntersection) {
+    protected void removeIntersection(Intersection nonEmptyIntersection) {
         graph.removeVertex(nonEmptyIntersection);
     }
 
@@ -99,7 +99,7 @@ public class RegionContainer {
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
-    public void addIntersection(Intersection intersection) {
+    protected void addIntersection(Intersection intersection) {
         graph.addVertex(intersection);
             graph.vertexSet().stream()
                     .filter(intersection::isOrthogonalTo)

--- a/src/main/java/quentin/core/RegionContainer.java
+++ b/src/main/java/quentin/core/RegionContainer.java
@@ -33,15 +33,7 @@ public class RegionContainer {
     }
 
     void removeIntersection(Intersection nonEmptyIntersection) {
-//        if (nonEmptyIntersection.hasStone(Stone.NONE)) {
-//            graph.addVertex(nonEmptyIntersection);
-//            graph.vertexSet().stream()
-//                    .filter(nonEmptyIntersection::isOrthogonalTo)
-//                    .forEach(orthogonalIntersection -> graph.addEdge(orthogonalIntersection, nonEmptyIntersection));
-//        } else {
-            boolean isRemoved = graph.removeVertex(nonEmptyIntersection);
-            System.out.println(isRemoved);
-//        }
+        graph.removeVertex(nonEmptyIntersection);
     }
 
     private List<Set<Intersection>> getRegions() {

--- a/src/main/java/quentin/core/RegionContainer.java
+++ b/src/main/java/quentin/core/RegionContainer.java
@@ -32,8 +32,15 @@ public class RegionContainer {
         new GridGraphGenerator<Intersection, DefaultEdge>(boardSize, boardSize).generateGraph(graph, null);
     }
 
-    void removeNonEmptyIntersection(Intersection nonEmptyIntersection) {
-        graph.removeVertex(nonEmptyIntersection);
+    void updateRegionContainer(Intersection nonEmptyIntersection) {
+        if (nonEmptyIntersection.hasStone(Stone.NONE)) {
+            graph.addVertex(nonEmptyIntersection);
+            graph.vertexSet().stream()
+                    .filter(nonEmptyIntersection::isOrthogonalTo)
+                    .forEach(orthogonalIntersection -> graph.addEdge(orthogonalIntersection, nonEmptyIntersection));
+        } else {
+            graph.removeVertex(nonEmptyIntersection);
+        }
     }
 
     private List<Set<Intersection>> getRegions() {

--- a/src/main/java/quentin/core/RegionContainer.java
+++ b/src/main/java/quentin/core/RegionContainer.java
@@ -32,15 +32,16 @@ public class RegionContainer {
         new GridGraphGenerator<Intersection, DefaultEdge>(boardSize, boardSize).generateGraph(graph, null);
     }
 
-    void updateRegionContainer(Intersection nonEmptyIntersection) {
-        if (nonEmptyIntersection.hasStone(Stone.NONE)) {
-            graph.addVertex(nonEmptyIntersection);
-            graph.vertexSet().stream()
-                    .filter(nonEmptyIntersection::isOrthogonalTo)
-                    .forEach(orthogonalIntersection -> graph.addEdge(orthogonalIntersection, nonEmptyIntersection));
-        } else {
-            graph.removeVertex(nonEmptyIntersection);
-        }
+    void removeIntersection(Intersection nonEmptyIntersection) {
+//        if (nonEmptyIntersection.hasStone(Stone.NONE)) {
+//            graph.addVertex(nonEmptyIntersection);
+//            graph.vertexSet().stream()
+//                    .filter(nonEmptyIntersection::isOrthogonalTo)
+//                    .forEach(orthogonalIntersection -> graph.addEdge(orthogonalIntersection, nonEmptyIntersection));
+//        } else {
+            boolean isRemoved = graph.removeVertex(nonEmptyIntersection);
+            System.out.println(isRemoved);
+//        }
     }
 
     private List<Set<Intersection>> getRegions() {
@@ -104,5 +105,12 @@ public class RegionContainer {
                     return Map.entry(territory, stone);
                 })
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    public void addIntersection(Intersection intersection) {
+        graph.addVertex(intersection);
+            graph.vertexSet().stream()
+                    .filter(intersection::isOrthogonalTo)
+                    .forEach(orthogonalIntersection -> graph.addEdge(orthogonalIntersection, intersection));
     }
 }

--- a/src/main/java/quentin/core/RegionContainer.java
+++ b/src/main/java/quentin/core/RegionContainer.java
@@ -17,7 +17,7 @@ public class RegionContainer {
     private final Graph<Intersection, DefaultEdge> graph;
     private final List<Intersection> intersections;
 
-    RegionContainer(List<Intersection> allEmptyIntersections, int boardSize) {
+    protected RegionContainer(List<Intersection> allEmptyIntersections, int boardSize) {
         this.intersections = allEmptyIntersections;
         Supplier<Intersection> vertexSupplier = new Supplier<>() {
             private int index = 0;
@@ -90,7 +90,7 @@ public class RegionContainer {
         }
     }
 
-    Map<Set<Intersection>, Stone> getTerritoriesAndStonesToFill(Stone lastPlay) {
+    protected Map<Set<Intersection>, Stone> getTerritoriesAndStonesToFill(Stone lastPlay) {
         return getTerritories().stream()
                 .map(territory -> {
                     Stone stone = getStoneToFillTerritory(territory, lastPlay);

--- a/src/main/java/quentin/exceptions/IllegalMoveException.java
+++ b/src/main/java/quentin/exceptions/IllegalMoveException.java
@@ -3,8 +3,8 @@ package quentin.exceptions;
 import quentin.core.Position;
 
 public class IllegalMoveException extends QuentinException {
-    public IllegalMoveException(Position position){
-        super("Player cannot put a stone diagonally adjacent to another stone of the same colour in this " + position +
-                " without a colour alike orthogonally adjacent.");
+    public IllegalMoveException(Position position) {
+        super("You cannot put a stone diagonally adjacent to another stone of the same colour in this " + position +
+                " if they not have a shared colour alike orthogonal stone.");
     }
 }

--- a/src/test/java/quentin/core/BoardShould.java
+++ b/src/test/java/quentin/core/BoardShould.java
@@ -1,6 +1,8 @@
 package quentin.core;
 
+import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -113,9 +115,15 @@ public class BoardShould {
         assertEquals(Stone.BLACK, customBoard.colorWithCompleteChain());
     }
 
-    @Test
-    public void provideCorrectColourAlikeDiagonallyAdjacentStones() {
+    @TestFactory
+    Collection<DynamicTest> provideCorrectColourAlikeDiagonallyAdjacentStones(){
         Board customBoard = Board.buildBoard(4);
+        customBoard.addStoneAt(Stone.BLACK, in(2, 2));
+        customBoard.addStoneAt(Stone.BLACK, in(1, 1));
+        customBoard.addStoneAt(Stone.BLACK, in(3, 3));
+        customBoard.addStoneAt(Stone.WHITE, in(1, 3));
+        customBoard.addStoneAt(Stone.WHITE, in(3, 1));
+
         List<Intersection> blackIntersections = List.of(
                 customBoard.intersectionAt(in(1, 1)),
                 customBoard.intersectionAt(in(3, 3))
@@ -126,20 +134,26 @@ public class BoardShould {
                 customBoard.intersectionAt(in(3, 1))
         );
 
-        customBoard.addStoneAt(Stone.BLACK, in(1, 1));
-        customBoard.addStoneAt(Stone.BLACK, in(3, 3));
-        customBoard.addStoneAt(Stone.WHITE, in(1, 3));
-        customBoard.addStoneAt(Stone.WHITE, in(3, 1));
-
         Set<Intersection> colourAlikeDiagonallyAdjacentIntersections =
                 customBoard.getDiagonallyAdjacentIntersectionsOfColour(customBoard.intersectionAt(in(2, 2)), Stone.BLACK);
-        assertTrue(colourAlikeDiagonallyAdjacentIntersections.containsAll(blackIntersections));
-        assertFalse(colourAlikeDiagonallyAdjacentIntersections.containsAll(whiteIntersections));
+
+        return List.of(
+                DynamicTest.dynamicTest("Black Diagonal Intersections",
+                        () -> assertTrue(colourAlikeDiagonallyAdjacentIntersections.containsAll(blackIntersections))),
+                DynamicTest.dynamicTest("White Diagonal Intersections",
+                        () -> assertFalse(colourAlikeDiagonallyAdjacentIntersections.containsAll(whiteIntersections)))
+        );
     }
 
-    @Test
-    public void provideCorrectColourAlikeOrthogonallyAdjacentStones() {
+    @TestFactory
+    Collection<DynamicTest> provideCorrectColourAlikeOrthogonallyAdjacentStones() {
         Board customBoard = Board.buildBoard(4);
+        customBoard.addStoneAt(Stone.WHITE, in(2, 2));
+        customBoard.addStoneAt(Stone.BLACK, in(1, 2));
+        customBoard.addStoneAt(Stone.BLACK, in(3, 2));
+        customBoard.addStoneAt(Stone.WHITE, in(2, 1));
+        customBoard.addStoneAt(Stone.WHITE, in (2, 3));
+
         List<Intersection> blackIntersections = List.of(
                 customBoard.intersectionAt(in(1, 2)),
                 customBoard.intersectionAt(in(3, 2))
@@ -149,17 +163,17 @@ public class BoardShould {
                 customBoard.intersectionAt(in(2, 3))
         );
 
-        customBoard.addStoneAt(Stone.BLACK, in(2, 2));
-        customBoard.addStoneAt(Stone.BLACK, in(1, 2));
-        customBoard.addStoneAt(Stone.BLACK, in(3, 2));
-        customBoard.addStoneAt(Stone.WHITE, in(2, 1));
-        customBoard.addStoneAt(Stone.WHITE, in (2, 3));
-
         Set<Intersection> colourAlikeOrthogonallyAdjacentIntersections =
                 customBoard.getOrthogonallyAdjacentIntersectionsOfColour(
-                        customBoard.intersectionAt(in(2, 2)), Stone.BLACK
+                        customBoard.intersectionAt(in(2, 2)), Stone.WHITE
                 );
-        assertTrue(colourAlikeOrthogonallyAdjacentIntersections.containsAll(blackIntersections));
-        assertFalse(colourAlikeOrthogonallyAdjacentIntersections.containsAll(whiteIntersections));
+
+        return List.of(
+                DynamicTest.dynamicTest("Black Diagonal Intersections",
+                        () -> assertFalse(colourAlikeOrthogonallyAdjacentIntersections.containsAll(blackIntersections))),
+                DynamicTest.dynamicTest("White Diagonal Intersections",
+                        () -> assertTrue(colourAlikeOrthogonallyAdjacentIntersections.containsAll(whiteIntersections)))
+        );
+
     }
 }

--- a/src/test/java/quentin/core/BoardShould.java
+++ b/src/test/java/quentin/core/BoardShould.java
@@ -63,59 +63,6 @@ public class BoardShould {
         assertEquals(intersection.getStone(), stone);
     }
 
-//    @TestFactory
-//    Stream<DynamicTest> checkOrthogonalAdjacent() throws OutsideOfBoardException {
-//        Board customBoard = Board.buildBoard(13);
-//        customBoard.addStoneAt(Stone.WHITE, in(7, 9));
-//        customBoard.addStoneAt(Stone.WHITE, in(3, 4));
-//        customBoard.addStoneAt(Stone.WHITE, in(4, 4));
-//        customBoard.addStoneAt(Stone.WHITE, in(12, 5));
-//        customBoard.addStoneAt(Stone.WHITE, in(13, 5));
-//
-//        List<Intersection> inputList = List.of(
-//                customBoard.intersectionAt(in(7, 9)),
-//                customBoard.intersectionAt(in(3, 4)),
-//                customBoard.intersectionAt(in(12, 5))
-//        );
-//
-//        List<Boolean> outputList = List.of(false, true, true);
-//
-//        return inputList.stream()
-//                .map(intersection -> DynamicTest.dynamicTest("Checking Orthogonal Adjacent of " + intersection,
-//                        () -> {
-//                            int index = inputList.indexOf(intersection);
-//                            assertEquals(outputList.get(index), customBoard.existsOrthogonallyAdjacentWithStone(intersection, Stone.WHITE));
-//                        })
-//                );
-//    }
-
-
-//    @TestFactory
-//    Stream<DynamicTest> checkDiagonalAdjacent() throws OutsideOfBoardException {
-//        Board customBoard = Board.buildBoard(13);
-//        customBoard.addStoneAt(Stone.WHITE, in(7, 9));
-//        customBoard.addStoneAt(Stone.WHITE, in(3, 4));
-//        customBoard.addStoneAt(Stone.WHITE, in(2, 5));
-//        customBoard.addStoneAt(Stone.WHITE, in(12, 5));
-//        customBoard.addStoneAt(Stone.WHITE, in(13, 4));
-//
-//        List<Intersection> inputList = List.of(
-//                customBoard.intersectionAt(in(7, 9)),
-//                customBoard.intersectionAt(in(3, 4)),
-//                customBoard.intersectionAt(in(12, 5))
-//        );
-//
-//        List<Boolean> outputList = List.of(false, true, true);
-//
-//        return inputList.stream()
-//                .map(intersection -> DynamicTest.dynamicTest("Checking Diagonal Adjacent of " + intersection,
-//                        () -> {
-//                            int index = inputList.indexOf(intersection);
-//                            assertEquals(outputList.get(index), customBoard.existsDiagonallyAdjacentWithStone(intersection, Stone.WHITE));
-//                        })
-//                );
-//    }
-
     @Test
     public void fillTerritoryWithEqualNumberOfStoneOfTheSameColor() {
         int boardSize = 13;

--- a/src/test/java/quentin/core/BoardShould.java
+++ b/src/test/java/quentin/core/BoardShould.java
@@ -169,7 +169,7 @@ public class BoardShould {
     }
 
     @Test
-    public void provideCorrectDiagonallyAdjacentStones() {
+    public void provideCorrectColourAlikeDiagonallyAdjacentStones() {
         Board customBoard = Board.buildBoard(4);
         List<Intersection> blackIntersections = List.of(
                 customBoard.intersectionAt(in(1, 1)),
@@ -187,9 +187,33 @@ public class BoardShould {
         customBoard.addStoneAt(Stone.WHITE, in(3, 1));
         customBoard.addStoneAt(Stone.BLACK, in(2, 2));
 
-        Set<Intersection> colourAlikeAdjacentIntersections =
+        Set<Intersection> colourAlikeDiagonallyAdjacentIntersections =
                 customBoard.getColourAlikeDiagonallyAdjacentIntersections(customBoard.intersectionAt(in(2, 2)));
-        assertTrue(colourAlikeAdjacentIntersections.containsAll(blackIntersections));
-        assertFalse(colourAlikeAdjacentIntersections.containsAll(whiteIntersections));
+        assertTrue(colourAlikeDiagonallyAdjacentIntersections.containsAll(blackIntersections));
+        assertFalse(colourAlikeDiagonallyAdjacentIntersections.containsAll(whiteIntersections));
+    }
+
+    @Test
+    public void provideCorrectColourAlikeOrthogonallyAdjacentStones() {
+        Board customBoard = Board.buildBoard(4);
+        List<Intersection> blackIntersections = List.of(
+                customBoard.intersectionAt(in(1, 2)),
+                customBoard.intersectionAt(in(3, 2))
+        );
+        List<Intersection> whiteIntersections = List.of(
+                customBoard.intersectionAt(in(2, 1)),
+                customBoard.intersectionAt(in(2, 3))
+        );
+
+        customBoard.addStoneAt(Stone.BLACK, in(2, 2));
+        customBoard.addStoneAt(Stone.BLACK, in(1, 2));
+        customBoard.addStoneAt(Stone.BLACK, in(3, 2));
+        customBoard.addStoneAt(Stone.WHITE, in(2, 1));
+        customBoard.addStoneAt(Stone.WHITE, in (2, 3));
+
+        Set<Intersection> colourAlikeOrthogonallyAdjacentIntersections =
+                customBoard.getColourAlikeOrthogonallyAdjacentIntersections(customBoard.intersectionAt(in(2, 2)));
+        assertTrue(colourAlikeOrthogonallyAdjacentIntersections.containsAll(blackIntersections));
+        assertFalse(colourAlikeOrthogonallyAdjacentIntersections.containsAll(whiteIntersections));
     }
 }

--- a/src/test/java/quentin/core/BoardShould.java
+++ b/src/test/java/quentin/core/BoardShould.java
@@ -185,10 +185,9 @@ public class BoardShould {
         customBoard.addStoneAt(Stone.BLACK, in(3, 3));
         customBoard.addStoneAt(Stone.WHITE, in(1, 3));
         customBoard.addStoneAt(Stone.WHITE, in(3, 1));
-        customBoard.addStoneAt(Stone.BLACK, in(2, 2));
 
         Set<Intersection> colourAlikeDiagonallyAdjacentIntersections =
-                customBoard.getColourAlikeDiagonallyAdjacentIntersections(customBoard.intersectionAt(in(2, 2)));
+                customBoard.getDiagonallyAdjacentIntersectionsOfColour(customBoard.intersectionAt(in(2, 2)), Stone.BLACK);
         assertTrue(colourAlikeDiagonallyAdjacentIntersections.containsAll(blackIntersections));
         assertFalse(colourAlikeDiagonallyAdjacentIntersections.containsAll(whiteIntersections));
     }
@@ -212,7 +211,9 @@ public class BoardShould {
         customBoard.addStoneAt(Stone.WHITE, in (2, 3));
 
         Set<Intersection> colourAlikeOrthogonallyAdjacentIntersections =
-                customBoard.getColourAlikeOrthogonallyAdjacentIntersections(customBoard.intersectionAt(in(2, 2)));
+                customBoard.getOrthogonallyAdjacentIntersectionsOfColour(
+                        customBoard.intersectionAt(in(2, 2)), Stone.BLACK
+                );
         assertTrue(colourAlikeOrthogonallyAdjacentIntersections.containsAll(blackIntersections));
         assertFalse(colourAlikeOrthogonallyAdjacentIntersections.containsAll(whiteIntersections));
     }

--- a/src/test/java/quentin/core/BoardShould.java
+++ b/src/test/java/quentin/core/BoardShould.java
@@ -63,58 +63,58 @@ public class BoardShould {
         assertEquals(intersection.getStone(), stone);
     }
 
-    @TestFactory
-    Stream<DynamicTest> checkOrthogonalAdjacent() throws OutsideOfBoardException {
-        Board customBoard = Board.buildBoard(13);
-        customBoard.addStoneAt(Stone.WHITE, in(7, 9));
-        customBoard.addStoneAt(Stone.WHITE, in(3, 4));
-        customBoard.addStoneAt(Stone.WHITE, in(4, 4));
-        customBoard.addStoneAt(Stone.WHITE, in(12, 5));
-        customBoard.addStoneAt(Stone.WHITE, in(13, 5));
+//    @TestFactory
+//    Stream<DynamicTest> checkOrthogonalAdjacent() throws OutsideOfBoardException {
+//        Board customBoard = Board.buildBoard(13);
+//        customBoard.addStoneAt(Stone.WHITE, in(7, 9));
+//        customBoard.addStoneAt(Stone.WHITE, in(3, 4));
+//        customBoard.addStoneAt(Stone.WHITE, in(4, 4));
+//        customBoard.addStoneAt(Stone.WHITE, in(12, 5));
+//        customBoard.addStoneAt(Stone.WHITE, in(13, 5));
+//
+//        List<Intersection> inputList = List.of(
+//                customBoard.intersectionAt(in(7, 9)),
+//                customBoard.intersectionAt(in(3, 4)),
+//                customBoard.intersectionAt(in(12, 5))
+//        );
+//
+//        List<Boolean> outputList = List.of(false, true, true);
+//
+//        return inputList.stream()
+//                .map(intersection -> DynamicTest.dynamicTest("Checking Orthogonal Adjacent of " + intersection,
+//                        () -> {
+//                            int index = inputList.indexOf(intersection);
+//                            assertEquals(outputList.get(index), customBoard.existsOrthogonallyAdjacentWithStone(intersection, Stone.WHITE));
+//                        })
+//                );
+//    }
 
-        List<Intersection> inputList = List.of(
-                customBoard.intersectionAt(in(7, 9)),
-                customBoard.intersectionAt(in(3, 4)),
-                customBoard.intersectionAt(in(12, 5))
-        );
 
-        List<Boolean> outputList = List.of(false, true, true);
-
-        return inputList.stream()
-                .map(intersection -> DynamicTest.dynamicTest("Checking Orthogonal Adjacent of " + intersection,
-                        () -> {
-                            int index = inputList.indexOf(intersection);
-                            assertEquals(outputList.get(index), customBoard.existsOrthogonallyAdjacentWithStone(intersection, Stone.WHITE));
-                        })
-                );
-    }
-
-
-    @TestFactory
-    Stream<DynamicTest> checkDiagonalAdjacent() throws OutsideOfBoardException {
-        Board customBoard = Board.buildBoard(13);
-        customBoard.addStoneAt(Stone.WHITE, in(7, 9));
-        customBoard.addStoneAt(Stone.WHITE, in(3, 4));
-        customBoard.addStoneAt(Stone.WHITE, in(2, 5));
-        customBoard.addStoneAt(Stone.WHITE, in(12, 5));
-        customBoard.addStoneAt(Stone.WHITE, in(13, 4));
-
-        List<Intersection> inputList = List.of(
-                customBoard.intersectionAt(in(7, 9)),
-                customBoard.intersectionAt(in(3, 4)),
-                customBoard.intersectionAt(in(12, 5))
-        );
-
-        List<Boolean> outputList = List.of(false, true, true);
-
-        return inputList.stream()
-                .map(intersection -> DynamicTest.dynamicTest("Checking Diagonal Adjacent of " + intersection,
-                        () -> {
-                            int index = inputList.indexOf(intersection);
-                            assertEquals(outputList.get(index), customBoard.existsDiagonallyAdjacentWithStone(intersection, Stone.WHITE));
-                        })
-                );
-    }
+//    @TestFactory
+//    Stream<DynamicTest> checkDiagonalAdjacent() throws OutsideOfBoardException {
+//        Board customBoard = Board.buildBoard(13);
+//        customBoard.addStoneAt(Stone.WHITE, in(7, 9));
+//        customBoard.addStoneAt(Stone.WHITE, in(3, 4));
+//        customBoard.addStoneAt(Stone.WHITE, in(2, 5));
+//        customBoard.addStoneAt(Stone.WHITE, in(12, 5));
+//        customBoard.addStoneAt(Stone.WHITE, in(13, 4));
+//
+//        List<Intersection> inputList = List.of(
+//                customBoard.intersectionAt(in(7, 9)),
+//                customBoard.intersectionAt(in(3, 4)),
+//                customBoard.intersectionAt(in(12, 5))
+//        );
+//
+//        List<Boolean> outputList = List.of(false, true, true);
+//
+//        return inputList.stream()
+//                .map(intersection -> DynamicTest.dynamicTest("Checking Diagonal Adjacent of " + intersection,
+//                        () -> {
+//                            int index = inputList.indexOf(intersection);
+//                            assertEquals(outputList.get(index), customBoard.existsDiagonallyAdjacentWithStone(intersection, Stone.WHITE));
+//                        })
+//                );
+//    }
 
     @Test
     public void fillTerritoryWithEqualNumberOfStoneOfTheSameColor() {

--- a/src/test/java/quentin/core/BoardShould.java
+++ b/src/test/java/quentin/core/BoardShould.java
@@ -1,8 +1,6 @@
 package quentin.core;
 
-import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;

--- a/src/test/java/quentin/core/BoardShould.java
+++ b/src/test/java/quentin/core/BoardShould.java
@@ -167,4 +167,29 @@ public class BoardShould {
         customBoard.addStoneAt(Stone.BLACK, in(3, 2));
         assertEquals(Stone.BLACK, customBoard.colorWithCompleteChain());
     }
+
+    @Test
+    public void provideCorrectDiagonallyAdjacentStones() {
+        Board customBoard = Board.buildBoard(4);
+        List<Intersection> blackIntersections = List.of(
+                customBoard.intersectionAt(in(1, 1)),
+                customBoard.intersectionAt(in(3, 3))
+        );
+
+        List<Intersection> whiteIntersections = List.of(
+                customBoard.intersectionAt(in(1, 3)),
+                customBoard.intersectionAt(in(3, 1))
+        );
+
+        customBoard.addStoneAt(Stone.BLACK, in(1, 1));
+        customBoard.addStoneAt(Stone.BLACK, in(3, 3));
+        customBoard.addStoneAt(Stone.WHITE, in(1, 3));
+        customBoard.addStoneAt(Stone.WHITE, in(3, 1));
+        customBoard.addStoneAt(Stone.BLACK, in(2, 2));
+
+        Set<Intersection> colourAlikeAdjacentIntersections =
+                customBoard.getColourAlikeDiagonallyAdjacentIntersections(customBoard.intersectionAt(in(2, 2)));
+        assertTrue(colourAlikeAdjacentIntersections.containsAll(blackIntersections));
+        assertFalse(colourAlikeAdjacentIntersections.containsAll(whiteIntersections));
+    }
 }


### PR DESCRIPTION
Fixed invalid move bug #55. 
Substituted the two functions for checking the _existence_ of orthogonal and diagonal intersections with two functions that _return_ respectively the orthogonal and diagonal, colour alike, intersections.

Two tests were added; @demirbilek95 could check them and see if you can refactor them with `DynamicTests` or other?